### PR TITLE
Adding installer for osx/linux + bazel build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,37 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Setup Bazel and Dependencies"
+          name: "Linux Build Environment"
+          command: |
+            sudo apt-get update
+            sudo apt-get install --reinstall build-essential
+
+      - run:
+          name: " ✅   Setup Bazel and Dependencies"
           command: |
             /usr/bin/env bash bin/setup
 
       - run:
-          name: "Run Bazel Build"
+          name: "Install Some Twinkie Crapola with Native Extensions"
+          command: |
+            gem install jaro_winkler -v '1.5.4' --verbose
+
+      - run:
+          name: " ✅   Bazel Build"
           command: |
             bazel build //...:all
+            bazel query //...:all
+
+      - run:
+          name: " ✅    Run HelloWorld CLI via Bazel"
+          command: |
+            bazel run //ruby/gems/hello_world:cli spanish
+            bazel run //ruby/gems/hello_world:cli japanese
+
+      - run:
+          name: " ✅   Run HelloWorld SPECS via Bazel"
+          command: |
+            bazel run //ruby/gems/hello_world:specs
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,28 @@ jobs:
             gem install relaxed-rubocop --version $(gem.lock.version relaxed-rubocop) --no-doc
             rubocop -E -P
 
+  bazel:
+    docker:
+      - image: circleci/ruby:2.6.5
+    working_directory: /home/circleci/repo
+    environment:
+      HELLO_WORLD_PATH: /home/circleci/repo/ruby/gems/hello_world
+    steps:
+      - checkout
+      - run:
+          name: "Setup Bazel and Dependencies"
+          command: |
+            /usr/bin/env bash bin/setup
+
+      - run:
+          name: "Run Bazel Build"
+          command: |
+            bazel build //...:all
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build
       - style
+      - bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Run RuboCop, but Skip Bundle Install"
+          name: " ✅   Run Ruby Style Check"
           command: |
-            cd ${HELLO_WORLD_PATH}
-            function gem.lock.version() { grep " $1 (" Gemfile.lock | awk '{print $2}' | tr -d '()'; }
-            gem install rubocop --version $(gem.lock.version rubocop) --no-doc
-            gem install relaxed-rubocop --version $(gem.lock.version relaxed-rubocop) --no-doc
-            rubocop -E -P
+            /usr/bin/env bash bin/ruby-check
 
   bazel:
     docker:
@@ -64,26 +60,16 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Linux Build Environment"
-          command: |
-            sudo apt-get update
-            sudo apt-get install --reinstall build-essential
-
-      - run:
-          name: " ✅   Setup Bazel and Dependencies"
+          name: " ✅   Run Setup"
           command: |
             /usr/bin/env bash bin/setup
 
       - run:
-          name: "Install Some Twinkie Crapola with Native Extensions"
+          name: " ✅   Run Bazel Commands & Build"
           command: |
-            gem install jaro_winkler -v '1.5.4' --verbose
-
-      - run:
-          name: " ✅   Bazel Build"
-          command: |
-            bazel build //...:all
             bazel query //...:all
+            echo
+            bazel build //...:all
 
       - run:
           name: " ✅    Run HelloWorld CLI via Bazel"

--- a/bin/deps
+++ b/bin/deps
@@ -15,5 +15,3 @@ export BashMaticURL="https://github.com/kigster/bashmatic"
 }
 
 source "${BashMatic}/init.sh"
-
-

--- a/bin/ruby-check
+++ b/bin/ruby-check
@@ -2,17 +2,15 @@
 
 export COLUMNS=90
 
-[[ -x bin/deps ]] && source bin/deps
-[[ ! -f .rubocop.yml && -x bin/setup ]] && source bin/setup
+[[ -x bin/deps ]] && source "bin/deps"
+[[ -x bin/setup ]] && bin/setup ruby
 
 find . -type d -name coverage -exec rm -rf {} \;
 
-info "Running Rubocop, please wait..."
-code=0
-run::set-next show-output-on
-run "rubocop -C true -F -D 1>&1 >/dev/null || rubocop -a"
+hl::subtle "Running Rubocop, please wait..."
+run "rubocop -C true -F -D 1>&1 >/dev/null || rubocop -a || true"
 
-run::set-next abort-on-error
+run::set-next abort-on-error show-output-on
 run "rubocop -E -P"
 
 success "Your Ruby style is great!"

--- a/bin/setup
+++ b/bin/setup
@@ -5,24 +5,19 @@ set +e
 
 # install BASH dependencies
 function setup::bash() {
-  [[ -x bin/deps ]] && source bin/deps
-
+  [[ -x bin/deps ]] && source "bin/deps"
+  
   run::set-all abort-on-error
-
-  hl::subtle "Setting up BASH defaults..."
-
+  
   [[ -x bin/setup ]] || { 
-    printf "Please run this script from the WORKSPACE root.\n"
-    exit 1
+    printf "Please run this script from the WORKSPACE root.\n"; exit 1
   }
-
   [[ -f WORKSPACE ]] || {
-    error "This script should run from the Project's Workspace Folder"
-    exit 1
+    error "This script should run from the Project's Workspace Folder" ; exit 1
   }
 }
 
-function setup::ruby() {
+function setup::rubocop() {
   declare -a required_global_gems=(
     rubocop
     rubocop-performance
@@ -34,11 +29,6 @@ function setup::ruby() {
     1.5.1
     2.4
   )
-
-  rubygems_major_version=$(gem --version | awk '{print $3}' | cut -d. -f 1)
-  if [[ ${rubygems_major_version} -lt 3 ]]; then
-    run "gem update --system"
-  fi
 
   # abort on error
   run::set-all abort-on-error
@@ -52,24 +42,44 @@ function setup::ruby() {
   done
 }
 
+function setup::upgrade-rubygems() {
+  local rubygems_major_version
+  rubygems_major_version=$(gem --version | awk '{print $3}' | cut -d. -f 1)
+  if [[ ${rubygems_major_version} -lt 3 ]]; then
+    run "gem update --system"
+  fi
+}
 
 function setup::hook() {
-  hl::subtle "Configuring your pre-commit git hook..."
-
-  [[ -L .git/hooks/pre-commit ]] || \
+  [[ -L .git/hooks/pre-commit ]] || {
+    hl::subtle "Configuring your pre-commit git hook..."
     run "ln -nfs bin/pre-commit .git/hooks/pre-commit"
-
-  br; hr
+  }
 }
 
 function setup::bazel::darwin() {
   run "xcode-select --install 2>/dev/null || true"
   run "sudo xcodebuild -license accept"
-  run "brew tap bazelbuild/tap"
-  run "brew install bazelbuild/tap/bazel || true"
-  run "brew link --overwrite bazel"
-  run "brew upgrade bazelbuild/tap/bazel"
-  if [[ -n $(which bazel) ]] ; then
+  
+  local local_bazel_version
+  local_bazel_version=$(cat .bazel-version)
+
+  local installed_bazel_version
+  installed_bazel_version=$(brew info bazelbuild/tap/bazel | grep stable | awk '{print $3}')
+
+  if [[ -z ${installed_bazel_version} ]]; then
+    run "brew tap bazelbuild/tap"
+    run "brew install bazelbuild/tap/bazel || true"
+    run "brew link --overwrite bazel"
+  else
+    info "Nice, Bazel (${installed_bazel_version}) is already installed ${bldgrn} ✔ "
+  fi
+
+  [[ ${installed_bazel_version} != "${local_bazel_version}" ]] && {
+    run "brew info brew upgrade bazelbuild/tap/bazel "
+  }
+
+  if [[ -n $(command -v bazel) ]] ; then
     success "Installed bazel version $(bazel --version)"
   else
     error "Still can't find bazel, something must have gone wrong."
@@ -87,36 +97,48 @@ function setup::bazel::linux() {
 }
 
 function setup::bazel() {
-  # [[ -n $(which bazel) ]] && {
-  #   info "Bazel appears already installed, version $(bazel --version)"
-  #   return 0
-  # }
-
   local os
-  os="$(uname -s | tr 'A-Z' 'a-z')"
-  info "You will be asked to enter your password for sudo.. might as well do it now?"
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  info "You may be asked to enter your password for sudo..."
   sudo true
   local func="setup::bazel::${os}"
-  lib::util::is-a-function "${func}" && {
+  if lib::util::is-a-function "${func}"; then
     eval "${func}"
-  }
-}
-
-function setup::main() {
-  setup::bash
-  setup::ruby
-  setup::hook
-  setup::bazel
-
-  echo
-  success "Your repo is now ready for bazel."
-  echo; hr
-
-  if [[ -z ${CI} ]]; then
-    lib::run::ask "Would you like me to build it for you?"
-    run::set-next show-output-on
-    run "bazel build //...:all"
+  else
+    error "Operating System $(uname -s) is not currently supported."
   fi
 }
 
-setup::main "$@"
+function setup::ruby() {
+  setup::rubocop
+  setup::upgrade-rubygems
+}
+
+function setup::main() {
+  local action="$1"
+  func="setup::${action}"
+
+  if [[ -n ${action} ]]; then
+    lib::util::is-a-function "${func}" && {
+      h1 "Executing partial setup only: ${bldylw}${func}"
+      ${func}
+    }
+
+    return $?
+  fi
+  
+  setup::ruby
+  setup::bazel
+  [[ -n ${CI} ]] || setup::hook
+
+  success "Your repo is now ready for bazel." "Run 'bazel build //...:all' to build it."
+
+  return 0
+}
+
+setup::bash
+
+# Only execute main() if we were run as a script, not sourced in.
+bashmatic::validate-subshell 2>/dev/null && setup::main "$@"
+
+hr

--- a/bin/setup
+++ b/bin/setup
@@ -1,46 +1,122 @@
 #!/usr/bin/env bash
 
-[[ -x bin/deps ]] && source bin/deps
-[[ -f WORKSPACE ]] || {
-  error "This script should run from the Project's Workspace Folder"
-  exit 1
+# we handle errors using  run::set-all abort-on-error below
+set +e 
+
+# install BASH dependencies
+function setup::bash() {
+  [[ -x bin/deps ]] && source bin/deps
+
+  run::set-all abort-on-error
+
+  hl::subtle "Setting up BASH defaults..."
+
+  [[ -x bin/setup ]] || { 
+    printf "Please run this script from the WORKSPACE root.\n"
+    exit 1
+  }
+
+  [[ -f WORKSPACE ]] || {
+    error "This script should run from the Project's Workspace Folder"
+    exit 1
+  }
 }
 
-hl::subtle "Bazel/Repo setup script, to save you time!"
+function setup::ruby() {
+  declare -a required_global_gems=(
+    rubocop
+    rubocop-performance
+    relaxed-rubocop
+  )
 
-declare -a required_global_gems=(
-  rubocop
-  rubocop-performance
-  relaxed-rubocop
-)
+  declare -a required_gem_versions=(
+    0.76.0
+    1.5.1
+    2.4
+  )
 
-declare -a required_gem_versions=(
-  0.76.0
-  1.5.1
-  2.4
-)
+  rubygems_major_version=$(gem --version | awk '{print $3}' | cut -d. -f 1)
+  if [[ ${rubygems_major_version} -lt 3 ]]; then
+    run "gem update --system"
+  fi
 
-rubygems_major_version=$(gem --version | awk '{print $3}' | cut -d. -f 1)
+  # abort on error
+  run::set-all abort-on-error
 
-if [[ ${rubygems_major_version} -lt 3 ]]; then
-  run "gem update --system"
-fi
+  hl::subtle "Installing Globally rubocop gems..."
+  local index=0 
+  for gem in "${required_global_gems[@]}"; do
+    version="${required_gem_versions[${index}]}"
+    lib::gem::install "${gem}" "${version}"
+    index=$(( "${index}" + 1 ))
+  done
+}
 
-# abort on error
-run::set-all abort-on-error
 
-index=0 
-for gem in ${required_global_gems[@]}; do
-  version=${required_gem_versions[${index}]}
-  lib::gem::install ${gem} ${version}
-  index=$(( $index + 1 ))
-done
+function setup::hook() {
+  hl::subtle "Configuring your pre-commit git hook..."
 
-[[ -L .git/hooks/pre-commit ]] || run "ln -nfs bin/pre-commit .git/hooks/pre-commit"
+  [[ -L .git/hooks/pre-commit ]] || \
+    run "ln -nfs bin/pre-commit .git/hooks/pre-commit"
 
-if [[ ! -f .rubocop.yml ]] ; then
-  run "cp .templates/.rubocop.yml .rubocop.yml"
-fi
+  br; hr
+}
 
-printf "\n\n"; hr
-success "Your repo is now ready for bazel."
+function setup::bazel::darwin() {
+  run "xcode-select --install 2>/dev/null || true"
+  run "sudo xcodebuild -license accept"
+  run "brew tap bazelbuild/tap"
+  run "brew install bazelbuild/tap/bazel || true"
+  run "brew link --overwrite bazel"
+  run "brew upgrade bazelbuild/tap/bazel"
+  if [[ -n $(which bazel) ]] ; then
+    success "Installed bazel version $(bazel --version)"
+  else
+    error "Still can't find bazel, something must have gone wrong."
+    exit 1
+  fi
+}
+
+function setup::bazel::linux() {
+  run "sudo apt install curl"
+  run "curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -"
+  run "echo \"deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8\" | sudo tee /etc/apt/sources.list.d/bazel.list"
+  run "sudo apt update && sudo apt install bazel"
+  run "sudo apt update && sudo apt full-upgrade"
+  run "sudo apt install openjdk-11-jdk"
+}
+
+function setup::bazel() {
+  # [[ -n $(which bazel) ]] && {
+  #   info "Bazel appears already installed, version $(bazel --version)"
+  #   return 0
+  # }
+
+  local os
+  os="$(uname -s | tr 'A-Z' 'a-z')"
+  info "You will be asked to enter your password for sudo.. might as well do it now?"
+  sudo true
+  local func="setup::bazel::${os}"
+  lib::util::is-a-function "${func}" && {
+    eval "${func}"
+  }
+}
+
+function setup::main() {
+  setup::bash
+  setup::ruby
+  setup::hook
+  setup::bazel
+
+  echo
+  success "Your repo is now ready for bazel."
+  echo; hr
+
+  if [[ -z ${CI} ]]; then
+    lib::run::ask "Would you like me to build it for you?"
+    run::set-next show-output-on
+    run "bazel build //...:all"
+  fi
+}
+
+setup::main "$@"

--- a/ruby/apps/hello-world-web/app.rb
+++ b/ruby/apps/hello-world-web/app.rb
@@ -6,7 +6,7 @@ require 'hello_world'
 
 get '/' do
   language = HelloWorld.determine_language(params['l'])
-  <<~EOF
+  <<~HTML
     <html>
     <body style="font-family: Corbel, sans-serif; background-color: #FFFFE0;">
     <div style="margin: 100px auto; text-align: center; border: 1px solid #333; border-radius: 10px; width: 500px; box-shadow: 5px 5px 15px 0px #999; background-color: white;">
@@ -23,5 +23,5 @@ get '/' do
     </div>
     </body>
     </html>
-  EOF
+  HTML
 end

--- a/ruby/gems/hello_world/Gemfile
+++ b/ruby/gems/hello_world/Gemfile
@@ -9,6 +9,4 @@ gem 'colored2'
 group :test, :development do
   gem 'rake'
   gem 'rspec'
-  gem 'simplecov'
-  gem 'simplecov-formatter-badge'
 end

--- a/ruby/gems/hello_world/Gemfile
+++ b/ruby/gems/hello_world/Gemfile
@@ -8,9 +8,7 @@ gem 'colored2'
 
 group :test, :development do
   gem 'rake'
-  gem 'relaxed-rubocop'
   gem 'rspec'
-  gem 'rubocop'
   gem 'simplecov'
   gem 'simplecov-formatter-badge'
 end

--- a/ruby/gems/hello_world/Gemfile.lock
+++ b/ruby/gems/hello_world/Gemfile.lock
@@ -3,8 +3,6 @@ GEM
   specs:
     colored2 (3.1.2)
     diff-lcs (1.3)
-    docile (1.3.2)
-    json (2.2.0)
     rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -19,12 +17,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    simplecov (0.17.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-formatter-badge (0.1.0)
-    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
@@ -33,8 +25,6 @@ DEPENDENCIES
   colored2
   rake
   rspec
-  simplecov
-  simplecov-formatter-badge
 
 BUNDLED WITH
    1.17.3

--- a/ruby/gems/hello_world/Gemfile.lock
+++ b/ruby/gems/hello_world/Gemfile.lock
@@ -1,18 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
     colored2 (3.1.2)
     diff-lcs (1.3)
     docile (1.3.2)
-    jaro_winkler (1.5.4)
     json (2.2.0)
-    parallel (1.19.1)
-    parser (2.6.5.0)
-      ast (~> 2.4.0)
-    rainbow (3.0.0)
     rake (13.0.1)
-    relaxed-rubocop (2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -26,21 +19,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.77.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.6)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-formatter-badge (0.1.0)
     simplecov-html (0.10.2)
-    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -48,9 +32,7 @@ PLATFORMS
 DEPENDENCIES
   colored2
   rake
-  relaxed-rubocop
   rspec
-  rubocop
   simplecov
   simplecov-formatter-badge
 

--- a/ruby/gems/hello_world/exe/hello-world
+++ b/ruby/gems/hello_world/exe/hello-world
@@ -9,12 +9,13 @@ end
 require 'hello_world/cli'
 require 'colored2'
 
-code = 1
+code = 0
 
 begin
   ::HelloWorld::CLI.new(ARGV).execute!
 rescue StandardError => e
   warn e.message.bold.red
+  code = 1
 ensure
   exit code
 end

--- a/ruby/gems/hello_world/spec/spec_helper.rb
+++ b/ruby/gems/hello_world/spec/spec_helper.rb
@@ -18,11 +18,13 @@ if ENV['COVERAGE']
   end
 end
 
-puts "————————————————————————————"
-puts $LOAD_PATH.join("\n")
-puts Dir.pwd
-puts Dir.glob("**/*.rb").join("\n")
-puts "———————————————————————————"
+if ENV['DEBUG']
+  puts "————————————————————————————"
+  puts $LOAD_PATH.join("\n")
+  puts Dir.pwd
+  puts Dir.glob("**/*.rb").join("\n")
+  puts "———————————————————————————"
+end
 
 require 'hello_world/cli'
 

--- a/ruby/gems/hello_world/spec/spec_helper.rb
+++ b/ruby/gems/hello_world/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require 'simplecov'
-require 'simplecov-formatter-badge'
 
 if ENV['COVERAGE']
+  require 'simplecov'
+  require 'simplecov-formatter-badge'
   SimpleCov.formatter =
     SimpleCov::Formatter::MultiFormatter.new(
       [


### PR DESCRIPTION
In this PR, script `bin/setup` performs initial setup (which may not be needed eventually) but for now this is is good enough to see if Bazel builds on CircleCI.